### PR TITLE
[WIP]: Add fields to UserMetadata for notifications

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -15,6 +15,9 @@ use types::{
 };
 use yral_identity::ic_agent::sign_message;
 
+// Re-export the DeviceRegistrationToken
+pub use types::{DeviceRegistrationToken, NotificationKey};
+
 #[derive(Clone, Debug)]
 pub struct MetadataClient<const AUTH: bool> {
     base_url: Url,

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -7,9 +7,24 @@ use yral_identity::{msg_builder::Message, Signature};
 pub type ApiResult<T> = Result<T, ApiError>;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct DeviceRegistrationToken {
+    pub token: String,
+    pub device_fingerprint: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct NotificationKey {
+    pub key: String,
+    pub registration_tokens: Vec<DeviceRegistrationToken>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct UserMetadata {
     pub user_canister_id: Principal,
     pub user_name: String,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notification_key: Option<NotificationKey>,
 }
 
 impl From<UserMetadata> for Message {


### PR DESCRIPTION
We need to add two new field to the `UserMetadata` for adding notification support.
- [x] `registration_tokens: Vec<DeviceRegistrationToken>`
- [x] `notification_key: String`

The `DeviceRegistrationToken` will contain the actual `token` and a `device_fingerprint` field to identify the device

#6 