### PR TITLE
Update CI actions to latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - run: touch config.toml
 
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ inputs.publish-artifact }}
         with:
           name: build-musl

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-musl
       - run: chmod +x target/x86_64-unknown-linux-musl/release/yral-metadata-server


### PR DESCRIPTION
The CI actions: `actions/upload-artifact@v3` and `actions/download-artifact@v3` have been deprecated. (https://github.com/actions/upload-artifact/issues/635)

Hence, we need to update them to the newer version i.e. v4